### PR TITLE
Fix nanoinit url

### DIFF
--- a/index.html
+++ b/index.html
@@ -2014,7 +2014,7 @@
             </div>
             <h3 class='category'>Containers & Infrastructure</h3>
             <div class='project'>
-              <a class='logo' href='https://github.com/nanopack/naninit'>
+              <a class='logo' href='https://github.com/nanopack/nanoinit'>
                 <?xml version="1.0" encoding="utf-8"?>
                 <!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
                 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
@@ -2098,7 +2098,7 @@
                 <h4>Docker Micro Init Process</h4>
                 <ul class='links'>
                   <li>
-                    <a href='https://github.com/nanopack/naninit'>Source Code</a>
+                    <a href='https://github.com/nanopack/nanoinit'>Source Code</a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
Replacing `https://github.com/nanopack/naninit` by `https://github.com/nanopack/nanoinit`